### PR TITLE
fix: spawn pg_dump child process

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
         "dotenv": "16.0.2",
         "express": "4.18.1",
         "typescript": "4.8.3"
-    },
-    "dependencies": {
-        "@getvim/execute": "1.0.0"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { defineEndpoint } from "@directus/extensions-sdk"
 import { FilesService, FoldersService } from "directus"
-import { execute } from "@getvim/execute"
 import * as dotenv from "dotenv"
 import fs from "fs"
+import util from "util"
+import childProccess from "child_process"
 
 import { errorHandler, getFileName, getFolderId } from "./utils"
 
+const exec = util.promisify(childProccess.exec)
 dotenv.config({ debug: true, path: __dirname + "/.env" })
 
 export default defineEndpoint({
@@ -28,15 +30,9 @@ export default defineEndpoint({
                     db.client as IDbClient
                 ).connectionSettings
 
-                await execute(`pg_dump --format=c --file=${fileName}`, {
-                    env: {
-                        PGHOST: host,
-                        PGPORT: String(port),
-                        PGDATABASE: database,
-                        PGUSER: user,
-                        PGPASSWORD: password,
-                    },
-                })
+                await exec(
+                    `PGHOST=${host} PGPORT=${port} PGDATABASE=${database} PGUSER=${user} PGPASSWORD=${password} pg_dump --format=c --file=${fileName}`
+                )
 
                 await filesService.uploadOne(fs.createReadStream(fileName), {
                     title: fileName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,11 +979,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@getvim/execute@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@getvim/execute/-/execute-1.0.0.tgz#c6265e94caff8f1c52dee565a5b8a90166910612"
-  integrity sha512-DBtKHtKq4GKNnHL8pmiZb2y7uhkfVaQljqlmOJODDtJJfVOPQtUMMJCbEBTbvrqTnOlzgcgftUIsJCbLNgukdg==
-
 "@godaddy/terminus@^4.10.2":
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/@godaddy/terminus/-/terminus-4.11.2.tgz#86e8e0c40ad64eb62f5e2c3ee5c20beff97d9a2d"


### PR DESCRIPTION
Using `@getvim/execute` we can't spawn the process inside docker containers. This commit replaces the lib and uses node child_process to spawn pg_dump command.

Closes #3 